### PR TITLE
Fixes Uncaught SyntaxError: Unexpected token const

### DIFF
--- a/background.js
+++ b/background.js
@@ -11,8 +11,8 @@ const handler = function (details) {
 
     let headers = details.requestHeaders;
     let blockingResponse = {};
-
-    for (let i = 0, const l = headers.length; i < l; ++i) {
+    const l = headers.length
+    for (let i = 0; i < l; ++i) {
         if (headers[i].name == 'User-Agent') {
             headers[i].value = 'Mozilla/5.0 (Windows NT 9.0; WOW64; Trident/7.0; rv:11.0) like Gecko';
             break;


### PR DESCRIPTION
I noticed when loading the unpacked extention into chrome it failed with the error `Uncaught SyntaxError: Unexpected token const` I made some changes to the code that have fixed the error. 