### PR TITLE
Duplicate of ZusorCode/GoodTwitter#23

### DIFF
--- a/fix-twitter.js
+++ b/fix-twitter.js
@@ -1,0 +1,4 @@
+// simply tell the javascript of the page that we're on an up-to-date version
+Object.defineProperty(navigator, 'userAgent', {
+  get: ()=>"Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/74.0.3729.169 Safari/537.36"
+})

--- a/manifest.json
+++ b/manifest.json
@@ -16,6 +16,13 @@
     "persistent": true
   },
 
+  "content_scripts": [
+    {
+      "matches": ["https://*.twitter.com/*"],
+      "js": ["fix-twitter.js"]
+    }
+  ],
+
   "browser_action": {
     "default_popup": "popup/info.html"
   },

--- a/popup/info.html
+++ b/popup/info.html
@@ -10,6 +10,6 @@
 <p>If the add-on stops working for you, go <a href="https://github.com/ZusorCode/GoodTwitterChrome/blob/master/troubleshooting.md" target="_blank">here</a> for troubleshooting.</p>
 <p>If you have an issue that is not mentioned report it <a href="https://github.com/ZusorCode/GoodTwitterChrome/issues" target="_blank">here</a>.</p>
 <p>GoodTwitter is <a href="https://github.com/ZusorCode/GoodTwitterChrome" target="_blank">open-source</a>. Pull requests and contributions are appreciated.</p>
-<p>Coded by <a href="https://twitter.com/ZusorOW" target="_blank">Zusor.</a></p>
+<p>Coded by <a href="https://twitter.com/ZusorOW">Zusor</a> and <a href="https://smooch.computer/">zoe.</a></p>
 </body>
 </html>


### PR DESCRIPTION
I don't actually know if ZusorCode/GoodTwitter#23 is relevant on Chrome as I don't have Chrome installed. If you go on Twitter with this installed, do `navigator.userAgent` in the developer tools console, and it says nothing about Waterfox in the value it returns, then this isn't necessary and can be safely denied.