### PR TITLE
Change UA to Gecko on Windows 10. fix #46

### DIFF
--- a/background.js
+++ b/background.js
@@ -14,7 +14,7 @@ const handler = function (details) {
     const l = headers.length;
     for (let i = 0; i < l; ++i) {
         if (headers[i].name === 'User-Agent') {
-            headers[i].value = 'Mozilla/5.0 (Windows NT 6.1; WOW64; Trident/7.0; AS; rv:11.0) Waterfox/56.2';
+            headers[i].value = 'Mozilla/5.0 (Windows NT 10.0; WOW64;) like Gecko';
         } else if (headers[i].name === 'Cookie') {
             headers[i].value = headers[i].value.replace(/rweb_optin=.*?(; .*)?$/i, "rweb_optin=off$1");
         }


### PR DESCRIPTION
It seems to work well on my machine.
But I'm not sure, because I don't know why Waterfox UA is used.